### PR TITLE
Allow multiple endpoints + headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,25 +36,27 @@ $ cat example/data.json
 }
 
 $ cat example/config.yml
-- name: example_global_value
-  path: $.counter
-  labels:
-    environment: beta # static label
+- endpoint: http://localhost:8000/example/data.json
+  mappings:
+    - name: example_global_value
+      path: $.counter
+      labels:
+        environment: beta # static label
 
-- name: example_value
-  type: object
-  path: $.values[*]?(@.state == "ACTIVE")
-  labels:
-    environment: beta # static label
-    id: $.id          # dynamic label
-  values:
-    active: 1      # static value
-    count: $.count # dynamic value
+    - name: example_value
+      type: object
+      path: $.values[*]?(@.state == "ACTIVE")
+      labels:
+        environment: beta # static label
+        id: $.id          # dynamic label
+      values:
+        active: 1      # static value
+        count: $.count # dynamic value
 
 $ python -m SimpleHTTPServer 8000 &
 Serving HTTP on 0.0.0.0 port 8000 ...
 
-$ ./json_exporter http://localhost:8000/example/data.json example/config.yml &
+$ ./json_exporter example/config.yml &
 INFO[2016-02-08T22:44:38+09:00] metric registered;name:<example_global_value>
 INFO[2016-02-08T22:44:38+09:00] metric registered;name:<example_value_active>
 INFO[2016-02-08T22:44:38+09:00] metric registered;name:<example_value_count>
@@ -66,6 +68,31 @@ example_value_active{environment="beta",id="id-A"} 1
 example_value_active{environment="beta",id="id-C"} 1
 example_value_count{environment="beta",id="id-A"} 1
 example_value_count{environment="beta",id="id-C"} 3
+```
+
+Headers & Additional Endpoints
+=============
+An example configuration for multiple endpoints, with headers:
+
+```
+- endpoint: http://example.com/endpoint-1
+  headers:
+  - Content-Type: application/json
+  - API-KEY: asdf
+  mappings:
+  - name: example_global
+    path: $.example
+- endpoint: http://example.com/endpoint-2
+  headers:
+  - API-KEY: foobar
+  mappings:
+  - name: example_value
+    type: object
+    path: $.example[*]
+    labels:
+      id: $.id
+    values:
+      default: 1
 ```
 
 See Also

--- a/example/config.yml
+++ b/example/config.yml
@@ -1,14 +1,16 @@
-- name: example_global_value
-  path: $.counter
-  labels:
-    environment: beta # static label
+- endpoint: http://localhost:8000/example/data.json
+  mappings:
+    - name: example_global_value
+      path: $.counter
+      labels:
+        environment: beta # static label
 
-- name: example_value
-  type: object
-  path: $.values[*]?(@.state == "ACTIVE")
-  labels:
-    environment: beta # static label
-    id: $.id          # dynamic label
-  values:
-    active: 1      # static value
-    count: $.count # dynamic value
+    - name: example_value
+      type: object
+      path: $.values[*]?(@.state == "ACTIVE")
+      labels:
+        environment: beta # static label
+        id: $.id          # dynamic label
+      values:
+        active: 1      # static value
+        count: $.count # dynamic value

--- a/json_exporter.go
+++ b/json_exporter.go
@@ -7,7 +7,7 @@ import (
 
 func main() {
 	opts := harness.NewExporterOpts("json_exporter", jsonexporter.Version)
-	opts.Usage = "[OPTIONS] HTTP_ENDPOINT CONFIG_PATH"
+	opts.Usage = "[OPTIONS] CONFIG_PATH"
 	opts.Init = jsonexporter.Init
 	harness.Main(opts)
 }

--- a/jsonexporter/collector.go
+++ b/jsonexporter/collector.go
@@ -12,6 +12,7 @@ import (
 type Collector struct {
 	Endpoint string
 	scrapers []JsonScraper
+	Headers  map[string]string
 }
 
 func compilePath(path string) (*jsonpath.Path, error) {
@@ -44,15 +45,22 @@ func compilePaths(paths map[string]string) (map[string]*jsonpath.Path, error) {
 	return compiledPaths, nil
 }
 
-func NewCollector(endpoint string, scrapers []JsonScraper) *Collector {
+func NewCollector(endpoint string, headers map[string]string, scrapers []JsonScraper) *Collector {
 	return &Collector{
 		Endpoint: endpoint,
+		Headers: headers,
 		scrapers: scrapers,
 	}
 }
 
 func (col *Collector) fetchJson() ([]byte, error) {
-	resp, err := http.Get(col.Endpoint)
+	client := &http.Client{}
+	req, err := http.NewRequest("GET", col.Endpoint, nil)
+	for name, value := range col.Headers{
+		req.Header.Add(name, value)
+	}
+
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch json from endpoint;endpoint:<%s>,err:<%s>", col.Endpoint, err)
 	}

--- a/jsonexporter/config.go
+++ b/jsonexporter/config.go
@@ -7,6 +7,7 @@ import (
 )
 
 type Config struct {
+    Endpoint string            `yaml:"endpoint"`
     Headers  map[string]string `yaml:"headers"`
     Mappings []*Mapping        `yaml:"mappings"`
 }

--- a/jsonexporter/config.go
+++ b/jsonexporter/config.go
@@ -6,7 +6,7 @@ import (
 	"io/ioutil"
 )
 
-type Config struct {
+type ModuleConfig struct {
     Endpoint string            `yaml:"endpoint"`
     Headers  map[string]string `yaml:"headers"`
     Mappings []*Mapping        `yaml:"mappings"`
@@ -29,25 +29,27 @@ func (mapping *Mapping) labelNames() []string {
 	return labelNames
 }
 
-func loadConfig(configPath string) (*Config, error) {
+func loadConfig(configPath string) ([]*ModuleConfig, error) {
 	data, err := ioutil.ReadFile(configPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load config;path:<%s>,err:<%s>", configPath, err)
 	}
 
-	var config Config
-	if err := yaml.Unmarshal(data, &config); err != nil {
+	var moduleConfigs []*ModuleConfig
+	if err := yaml.Unmarshal(data, &moduleConfigs); err != nil {
 		return nil, fmt.Errorf("failed to parse yaml;err:<%s>", err)
 	}
 	// Complete defaults
-	for _, mapping := range config.Mappings {
-		if mapping.Type == "" {
-			mapping.Type = DefaultScrapeType
-		}
-		if mapping.Help == "" {
-			mapping.Help = mapping.Name
+	for _, moduleConfig := range moduleConfigs {
+		for _, mapping := range moduleConfig.Mappings {
+			if mapping.Type == "" {
+				mapping.Type = DefaultScrapeType
+			}
+			if mapping.Help == "" {
+				mapping.Help = mapping.Name
+			}
 		}
 	}
 
-	return &config, nil
+	return moduleConfigs, nil
 }

--- a/jsonexporter/config.go
+++ b/jsonexporter/config.go
@@ -7,41 +7,46 @@ import (
 )
 
 type Config struct {
-	Name   string            `yaml:name`
-	Path   string            `yaml:path`
-	Labels map[string]string `yaml:labels`
-	Type   string            `yaml:type`
-	Help   string            `yaml:help`
-	Values map[string]string `yaml:values`
+    Headers  map[string]string `yaml:"headers"`
+    Mappings []*Mapping        `yaml:"mappings"`
 }
 
-func (config *Config) labelNames() []string {
-	labelNames := make([]string, 0, len(config.Labels))
-	for name := range config.Labels {
+type Mapping struct {
+	Name   string              `yaml:name`
+	Path   string              `yaml:path`
+	Labels map[string]string   `yaml:labels`
+	Type   string              `yaml:type`
+	Help   string              `yaml:help`
+	Values map[string]string   `yaml:values`
+}
+
+func (mapping *Mapping) labelNames() []string {
+	labelNames := make([]string, 0, len(mapping.Labels))
+	for name := range mapping.Labels {
 		labelNames = append(labelNames, name)
 	}
 	return labelNames
 }
 
-func loadConfig(configPath string) ([]*Config, error) {
+func loadConfig(configPath string) (*Config, error) {
 	data, err := ioutil.ReadFile(configPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load config;path:<%s>,err:<%s>", configPath, err)
 	}
 
-	var configs []*Config
-	if err := yaml.Unmarshal(data, &configs); err != nil {
+	var config Config
+	if err := yaml.Unmarshal(data, &config); err != nil {
 		return nil, fmt.Errorf("failed to parse yaml;err:<%s>", err)
 	}
 	// Complete defaults
-	for _, config := range configs {
-		if config.Type == "" {
-			config.Type = DefaultScrapeType
+	for _, mapping := range config.Mappings {
+		if mapping.Type == "" {
+			mapping.Type = DefaultScrapeType
 		}
-		if config.Help == "" {
-			config.Help = config.Name
+		if mapping.Help == "" {
+			mapping.Help = mapping.Name
 		}
 	}
 
-	return configs, nil
+	return &config, nil
 }

--- a/jsonexporter/init.go
+++ b/jsonexporter/init.go
@@ -47,14 +47,13 @@ var DefaultScrapeType = "value"
 func Init(c *cli.Context, reg *harness.MetricRegistry) (harness.Collector, error) {
 	args := c.Args()
 
-	if len(args) < 2 {
+	if len(args) < 1 {
 		cli.ShowAppHelp(c)
 		return nil, fmt.Errorf("not enough arguments")
 	}
 
 	var (
-		endpoint   = args[0]
-		configPath = args[1]
+		configPath = args[0]
 	)
 
 	config, err := loadConfig(configPath)
@@ -76,5 +75,5 @@ func Init(c *cli.Context, reg *harness.MetricRegistry) (harness.Collector, error
 		scrapers[i] = scraper
 	}
 
-	return NewCollector(endpoint, config.Headers, scrapers), nil
+	return NewCollector(config.Endpoint, config.Headers, scrapers), nil
 }

--- a/jsonexporter/scraper.go
+++ b/jsonexporter/scraper.go
@@ -14,18 +14,18 @@ type JsonScraper interface {
 }
 
 type ValueScraper struct {
-	*Config
+	*Mapping
 	valueJsonPath *jsonpath.Path
 }
 
-func NewValueScraper(config *Config) (JsonScraper, error) {
-	valuepath, err := compilePath(config.Path)
+func NewValueScraper(mapping *Mapping) (JsonScraper, error) {
+	valuepath, err := compilePath(mapping.Path)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse path;path:<%s>,err:<%s>", config.Path, err)
+		return nil, fmt.Errorf("failed to parse path;path:<%s>,err:<%s>", mapping.Path, err)
 	}
 
 	scraper := &ValueScraper{
-		Config:        config,
+		Mapping:       mapping,
 		valueJsonPath: valuepath,
 	}
 	return scraper, nil
@@ -89,17 +89,17 @@ type ObjectScraper struct {
 	valueJsonPaths map[string]*jsonpath.Path
 }
 
-func NewObjectScraper(config *Config) (JsonScraper, error) {
-	valueScraper, err := NewValueScraper(config)
+func NewObjectScraper(mapping *Mapping) (JsonScraper, error) {
+	valueScraper, err := NewValueScraper(mapping)
 	if err != nil {
 		return nil, err
 	}
 
-	labelPaths, err := compilePaths(config.Labels)
+	labelPaths, err := compilePaths(mapping.Labels)
 	if err != nil {
 		return nil, err
 	}
-	valuePaths, err := compilePaths(config.Values)
+	valuePaths, err := compilePaths(mapping.Values)
 	if err != nil {
 		return nil, err
 	}
@@ -158,13 +158,13 @@ func (obsc *ObjectScraper) Scrape(data []byte, reg *harness.MetricRegistry) erro
 			labels[name] = string(value)
 		}
 
-		for name, configValue := range obsc.Values {
+		for name, mappingValue := range obsc.Values {
 			var metricValue float64
 			path := obsc.valueJsonPaths[name]
 
 			if path == nil {
 				// Static value
-				value, err := obsc.parseValue([]byte(configValue))
+				value, err := obsc.parseValue([]byte(mappingValue))
 				if err != nil {
 					log.Errorf("could not use configured value as float number;name:<%s>,err:<%s>", err)
 					continue

--- a/jsonexporter/version.go
+++ b/jsonexporter/version.go
@@ -1,3 +1,3 @@
 package jsonexporter
 
-const Version = "0.0.1"
+const Version = "0.1.1"


### PR DESCRIPTION
**My use case:** Needing to scrape multiple different endpoints without running a separate exporter + config combo for each. I also needed to be able to pass HTTP headers with my requests (in my case, auth keys).

**Implementation details:** I think the examples I've changed in/added to the README speak for themselves; the new config format is a list of "modules", each of which has an endpoint, an (optional) header map, and a list of JSON -> metric mappings.

**Goal of this PR:** To provide a functional version with these features for anyone who wants to build it; to get feedback on whether this is a good addition to the exporter or should remain a fork. The changes probably belong in separate PRs, but the changes built on each other and I'm not certain this repo is still being maintained.

@kawamuray Any feedback appreciated. (I'm quite new to golang and may have written unidiomatic code.)